### PR TITLE
Improve error logging plus increased number of virtual nodes to 5

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -703,7 +703,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   @Option(
       names = {"--sidechain-nodeCount"},
       description = "Sidechain total node count (default: ${DEFAULT-VALUE}")
-  public int nodeCount = 1;
+  public int nodeCount = 5;
 
   @Option(
       names = {"--sidechain-nodeNum"},

--- a/crosschain/src/main/java/org/hyperledger/besu/crosschain/ethereum/api/jsonrpc/CrosschainProcessor.java
+++ b/crosschain/src/main/java/org/hyperledger/besu/crosschain/ethereum/api/jsonrpc/CrosschainProcessor.java
@@ -219,7 +219,7 @@ public class CrosschainProcessor {
 
     if (result.isPresent()) {
       TransactionSimulatorResult simulatorResult = result.get();
-      LOG.info("Transaction Simulation Result {}", simulatorResult.getResult().getStatus());
+      LOG.info("Transaction Simulation Status {}", simulatorResult.getResult().getStatus());
 
       if (simulatorResult.isSuccessful()) {
         return Optional.empty();

--- a/crosschain/src/main/java/org/hyperledger/besu/crosschain/ethereum/crosschain/NodeBlsSigner.java
+++ b/crosschain/src/main/java/org/hyperledger/besu/crosschain/ethereum/crosschain/NodeBlsSigner.java
@@ -131,7 +131,11 @@ public class NodeBlsSigner {
       final SubordinateViewResult toBeSigned) {
     if (otherNodePartialSignatures.size() <= this.threshold - 1) {
       // TODO
-      throw new Error("Not enough partial signatures to create a signature");
+      throw new Error(
+          "Not enough partial signatures to create a signature. Have "
+              + otherNodePartialSignatures.size()
+              + ", need "
+              + (this.threshold - 1));
     }
 
     // TODO check that all partial signatures have unique x values.


### PR DESCRIPTION
Signed-off-by: Peter  Robinson <drinkcoffee@eml.cc>

The number of virtual nodes was changed from 1 to 5 to allow the threshold signing to work.

Multiple small improvements to the error logging.