### PR TITLE
Limit parallelism to 2, hoping for reliability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
           name: AcceptanceTests
           no_output_timeout: 40m
           environment:
-            GRADLE_MAX_TEST_FORKS: 3
+            GRADLE_MAX_TEST_FORKS: 2
           command: |
             ./gradlew --parallel acceptanceTest -Droot.log.level=DEBUG -Dacctests.showStandardStreams=true
       - capture_test_results


### PR DESCRIPTION
Use only 2 workers
Signed-off-by: Horacio Mijail Anton Quiles <hmijail@gmail.com>

