### PR TITLE
Configurable retrying and node logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
           environment:
             GRADLE_MAX_TEST_FORKS: 2
           command: |
-            ./gradlew --parallel acceptanceTest -Droot.log.level=DEBUG -Dacctests.keepLogs=true --tests "*crosschain*"
+            ./gradlew --parallel acceptanceTest -Droot.log.level=DEBUG -Dacctests.keepLogs=true -Dacctests.maxRetries=5 --tests "*crosschain*"
       - capture_test_results
       - store_artifacts:
           path: acceptance-tests/build/reports

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -128,10 +128,12 @@ task acceptanceTest(type: Test) {
   }
 
   retry {
-    maxRetries = 5
-    maxFailures = 3
+    mr = System.getProperty('acctests.maxRetries')
+    if (mr != null) {
+      maxRetries = Integer.valueOf(mr)
+      maxFailures = 3
+    }
   }
-
 
   testLogging {
     exceptionFormat = 'full'

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -128,9 +128,9 @@ task acceptanceTest(type: Test) {
   }
 
   retry {
-    mr = System.getProperty('acctests.maxRetries')
+    String mr = System.getProperty('acctests.maxRetries')
     if (mr != null) {
-      maxRetries = Integer.valueOf(mr)
+      maxRetries = Integer.parseInt(mr)
       maxFailures = 3
     }
   }

--- a/acceptance-tests/src/test-support/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/src/test-support/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -239,8 +239,10 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
     params.add("--key-value-storage");
     params.add("rocksdb");
 
-    // in testing, we don't mind logging on success, but we want max info on failures
-    params.add("--logging=DEBUG");
+    String level = System.getProperty("root.log.level");
+    if(level == null){
+      params.add("--logging="+level);
+    }
 
     LOG.info("Creating besu process with params {}", params);
     final ProcessBuilder processBuilder =

--- a/acceptance-tests/src/test-support/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/src/test-support/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -240,7 +240,7 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
     params.add("rocksdb");
 
     String level = System.getProperty("root.log.level");
-    if(level == null){
+    if(level != null){
       params.add("--logging="+level);
     }
 

--- a/acceptance-tests/src/test-support/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/src/test-support/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -240,8 +240,8 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
     params.add("rocksdb");
 
     String level = System.getProperty("root.log.level");
-    if(level != null){
-      params.add("--logging="+level);
+    if (level != null) {
+      params.add("--logging=" + level);
     }
 
     LOG.info("Creating besu process with params {}", params);


### PR DESCRIPTION
As requested, make configurable in the command line the log level for Besu processes and the number of test retries.
By default, log level of node is same as root log level of test, and retries are disabled.